### PR TITLE
square cutoff distance to match units

### DIFF
--- a/pdb_contact.py
+++ b/pdb_contact.py
@@ -34,7 +34,7 @@ def pdbContacting(pdb,target,cutoff,target_type="resname"):
     for t in target_list:
         contacts = []
         for a in all_coord:
-            if sum([(a[1][i]-t[1][i])**2 for i in range(3)]) < cutoff:
+            if sum([(a[1][i]-t[1][i])**2 for i in range(3)]) < cutoff_sq:
 
                 # ignore self
                 if t[0] == a[0]:


### PR DESCRIPTION
This fixes the problem mentioned in #1. 

This script was comparing the cutoff distance to the _squared_ distance between target and residue. I simply squared the cutoff distance to correct for the mismatching units. Another fix would be to square root the target-residue distance. Doesn't matter to me.
