### PR TITLE
Fix typo in download import name

### DIFF
--- a/pdbtools/helper/cmdline.py
+++ b/pdbtools/helper/cmdline.py
@@ -130,7 +130,7 @@ def parseCommandLine():
     # Download missing pdb files
     if len(to_download) > 0:
         to_download.sort()
-        if pdb_download.pdbDownload(to_download):
+        if download.pdbDownload(to_download):
             file_list.extend(["%s.pdb" % f for f in to_download])
         else:
             err = "pdb could not be found on rcsb!"


### PR DESCRIPTION
Hi there,

here is a fix for a minor problem I found while using `pdb_oligomer`. The import name name did not match the variable name in the code, causing a NameError.
